### PR TITLE
Update to FMSDK 3.1.0 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,5 +48,5 @@ dependencies {
     implementation 'com.google.android.gms:play-services-location:21.3.0'
 
     //Add FMSDK dependency
-    implementation 'com.fairmatic:sdk:3.0.2'
+    implementation 'com.fairmatic:sdk:3.1.0'
 }

--- a/app/src/main/java/com/fairmatic/sampleapp/fragments/OnDutyFragment.kt
+++ b/app/src/main/java/com/fairmatic/sampleapp/fragments/OnDutyFragment.kt
@@ -13,6 +13,7 @@ import com.fairmatic.sampleapp.Constants
 import com.fairmatic.sampleapp.R
 import com.fairmatic.sampleapp.manager.FairmaticManager
 import com.fairmatic.sampleapp.manager.SharedPrefsManager
+import com.fairmatic.sdk.Fairmatic
 import com.fairmatic.sdk.classes.FairmaticOperationCallback
 import com.fairmatic.sdk.classes.FairmaticOperationResult
 
@@ -23,6 +24,7 @@ class OnDutyFragment(val goOffDuty: () -> Unit) : Fragment() {
     private lateinit var pickupAPassengerButton: Button
     private lateinit var cancelRequestButton: Button
     private lateinit var dropAPassengerButton: Button
+    private lateinit var openIncidentReportingWebPageButton: Button
     private lateinit var offDutyButton: Button
     private lateinit var acceptNewRideReqButton: Button
 
@@ -52,6 +54,9 @@ class OnDutyFragment(val goOffDuty: () -> Unit) : Fragment() {
 
         dropAPassengerButton = layout.findViewById(R.id.dropAPassengerButton)
         dropAPassengerButton.setOnClickListener { dropAPassengerClicked() }
+
+        openIncidentReportingWebPageButton = layout.findViewById(R.id.openIncidentReportButton)
+        openIncidentReportingWebPageButton.setOnClickListener { openIncidentReportingUrl() }
 
         offDutyButton = layout.findViewById(R.id.offDutyButton)
         offDutyButton.setOnClickListener { offDutyClicked() }
@@ -160,6 +165,25 @@ class OnDutyFragment(val goOffDuty: () -> Unit) : Fragment() {
 
         sharedPrefsManager.isUserOnDuty = false
         goOffDuty()
+    }
+
+    private fun openIncidentReportingUrl() {
+        FairmaticManager.openIncidentReportingWebPage(
+            requireContext(),
+            object : FairmaticOperationCallback {
+                override fun onCompletion(result: FairmaticOperationResult) {
+                    if (result is FairmaticOperationResult.Success) {
+                        Log.d(Constants.LOG_TAG_DEBUG, "Incident reporting URL opened")
+                    }
+                    if (result is FairmaticOperationResult.Failure) {
+                        Log.d(
+                            Constants.LOG_TAG_DEBUG,
+                            "Opening incident reporting URL failed, error: " +
+                                    result.error.name
+                        )
+                    }
+                }
+            })
     }
 
     private fun refreshUI(){

--- a/app/src/main/java/com/fairmatic/sampleapp/fragments/OnDutyFragment.kt
+++ b/app/src/main/java/com/fairmatic/sampleapp/fragments/OnDutyFragment.kt
@@ -6,8 +6,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.ProgressBar
 import android.widget.TextView
 import android.widget.Toast
+import androidx.core.widget.ContentLoadingProgressBar
 import androidx.fragment.app.Fragment
 import com.fairmatic.sampleapp.Constants
 import com.fairmatic.sampleapp.R
@@ -24,8 +27,9 @@ class OnDutyFragment(val goOffDuty: () -> Unit) : Fragment() {
     private lateinit var pickupAPassengerButton: Button
     private lateinit var cancelRequestButton: Button
     private lateinit var dropAPassengerButton: Button
-    private lateinit var openIncidentReportingWebPageButton: Button
+    private lateinit var openIncidentReportingWebPageButton: LinearLayout
     private lateinit var offDutyButton: Button
+    private lateinit var loadingProgressBar: ProgressBar
     private lateinit var acceptNewRideReqButton: Button
 
     private val sharedPrefsManager by lazy { SharedPrefsManager.sharedInstance(requireContext()) }
@@ -56,7 +60,12 @@ class OnDutyFragment(val goOffDuty: () -> Unit) : Fragment() {
         dropAPassengerButton.setOnClickListener { dropAPassengerClicked() }
 
         openIncidentReportingWebPageButton = layout.findViewById(R.id.openIncidentReportButton)
-        openIncidentReportingWebPageButton.setOnClickListener { openIncidentReportingUrl() }
+        openIncidentReportingWebPageButton.setOnClickListener {
+            Log.d(Constants.LOG_TAG_DEBUG, "Opening incident reporting URL")
+            openIncidentReportingUrl() }
+
+        loadingProgressBar = layout.findViewById(R.id.loadingProgressBar)
+        loadingProgressBar.visibility = View.GONE
 
         offDutyButton = layout.findViewById(R.id.offDutyButton)
         offDutyButton.setOnClickListener { offDutyClicked() }
@@ -168,10 +177,12 @@ class OnDutyFragment(val goOffDuty: () -> Unit) : Fragment() {
     }
 
     private fun openIncidentReportingUrl() {
+        loadingProgressBar.visibility = View.VISIBLE
         FairmaticManager.openIncidentReportingWebPage(
             requireContext(),
             object : FairmaticOperationCallback {
                 override fun onCompletion(result: FairmaticOperationResult) {
+                    loadingProgressBar.visibility = View.GONE
                     if (result is FairmaticOperationResult.Success) {
                         Log.d(Constants.LOG_TAG_DEBUG, "Incident reporting URL opened")
                     }

--- a/app/src/main/java/com/fairmatic/sampleapp/manager/FairmaticManager.kt
+++ b/app/src/main/java/com/fairmatic/sampleapp/manager/FairmaticManager.kt
@@ -151,6 +151,10 @@ object FairmaticManager {
         Fairmatic.stopPeriod(context, callback)
     }
 
+    fun openIncidentReportingWebPage(context: Context, callback: FairmaticOperationCallback?) {
+        Fairmatic.openIncidentReportingWebPage(context, callback)
+    }
+
     private fun getNotificationManager(context: Context): NotificationManager {
         return context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
     }

--- a/app/src/main/res/drawable/claims_button_background.xml
+++ b/app/src/main/res/drawable/claims_button_background.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <gradient
+        android:startColor="#3064AF"
+        android:endColor="#01A9F4"
+        android:angle="0"
+        android:type="linear" />
+
+    <corners android:radius="24dp" />
+
+</shape>

--- a/app/src/main/res/layout/fragment_onduty.xml
+++ b/app/src/main/res/layout/fragment_onduty.xml
@@ -142,4 +142,17 @@
         app:layout_constraintTop_toBottomOf="@+id/openIncidentReportButton"
         app:layout_constraintVertical_bias="0.0" />
 
+    <ProgressBar
+        android:id="@+id/loadingProgressBar"
+        android:layout_width="100dp"
+        android:layout_height="100dp"
+        android:indeterminate="true"
+        android:indeterminateTint="@android:color/black"
+        android:elevation="10dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_onduty.xml
+++ b/app/src/main/res/layout/fragment_onduty.xml
@@ -95,19 +95,33 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/acceptNewRideRequestButton" />
 
-    <Button
+    <LinearLayout
         android:id="@+id/openIncidentReportButton"
         android:layout_width="0dp"
         android:layout_height="48dp"
         android:layout_marginStart="63dp"
         android:layout_marginTop="15dp"
         android:layout_marginEnd="63dp"
-        android:background="@color/colorButtonSecondary"
-        android:text="@string/open_incident_report"
+        android:background="@drawable/claims_button_background"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center"
+        android:orientation="horizontal"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/dropAPassengerButton" />
+        app:layout_constraintTop_toBottomOf="@+id/dropAPassengerButton">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/report_an_incident"
+            android:textColor="@android:color/white"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:fontFamily="sans-serif-medium" />
+
+    </LinearLayout>
 
     <Button
         android:id="@+id/offDutyButton"

--- a/app/src/main/res/layout/fragment_onduty.xml
+++ b/app/src/main/res/layout/fragment_onduty.xml
@@ -96,6 +96,20 @@
         app:layout_constraintTop_toBottomOf="@+id/acceptNewRideRequestButton" />
 
     <Button
+        android:id="@+id/openIncidentReportButton"
+        android:layout_width="0dp"
+        android:layout_height="48dp"
+        android:layout_marginStart="63dp"
+        android:layout_marginTop="15dp"
+        android:layout_marginEnd="63dp"
+        android:background="@color/colorButtonSecondary"
+        android:text="@string/open_incident_report"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/dropAPassengerButton" />
+
+    <Button
         android:id="@+id/offDutyButton"
         style="@style/CustomButtonStyle"
         android:layout_width="0dp"
@@ -111,7 +125,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/dropAPassengerButton"
+        app:layout_constraintTop_toBottomOf="@+id/openIncidentReportButton"
         app:layout_constraintVertical_bias="0.0" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -5,6 +5,7 @@
     <color name="colorAccent">#555555</color>
 
     <color name="colorButtonPrimary">#3F51B5</color>
+    <color name="colorButtonSecondary">#FF9800</color>
     <color name="custom_button_text_color">#FFFFFF</color>
     <color name="custom_button_disabled_text_color">#808080</color>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="on_duty_button_text">Go On Duty \u00A0 &#128663;</string>
     <string name="accept_new_ride_request">Accept New Ride Request</string>
     <string name="pickup_a_passenger">Pickup A Passenger</string>
-    <string name="open_incident_report">Open Incident Report Page</string>
+    <string name="report_an_incident">Report an incident</string>
     <string name="cancel_a_request">Cancel A Request</string>
     <string name="drop_a_passenger">Drop A Passenger</string>
     <string name="off_duty">Off Duty \u00A0 &#127969;</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="on_duty_button_text">Go On Duty \u00A0 &#128663;</string>
     <string name="accept_new_ride_request">Accept New Ride Request</string>
     <string name="pickup_a_passenger">Pickup A Passenger</string>
+    <string name="open_incident_report">Open Incident Report Page</string>
     <string name="cancel_a_request">Cancel A Request</string>
     <string name="drop_a_passenger">Drop A Passenger</string>
     <string name="off_duty">Off Duty \u00A0 &#127969;</string>


### PR DESCRIPTION
This pull request adds a new feature that allows users to open the incident reporting web page directly from the On Duty screen. The implementation includes UI changes, wiring up the button, and handling the operation callback. Additionally, the Fairmatic SDK is updated to version 3.1.0.

**Feature Addition: Incident Reporting Web Page**
- Added a new button `openIncidentReportButton` to the On Duty screen layout (`fragment_onduty.xml`). This button allows users to open the incident reporting web page. [[1]](diffhunk://#diff-2cc90647e373b8cfab272b21ce8aa82d69837f024d9f57547940a371231f8894R98-R111) [[2]](diffhunk://#diff-2cc90647e373b8cfab272b21ce8aa82d69837f024d9f57547940a371231f8894L114-R128) [[3]](diffhunk://#diff-5e01f7d37a66e4ca03deefc205d8e7008661cdd0284a05aaba1858e6b7bf9103R10) [[4]](diffhunk://#diff-f6f8135a64d2f255a1c82ad0928d7d3bdcacfa7b0c025b436fec3b57369e4b39R27)
- Implemented logic in `OnDutyFragment` to handle the button click, which calls `FairmaticManager.openIncidentReportingWebPage()` and logs the result of the operation. [[1]](diffhunk://#diff-f6f8135a64d2f255a1c82ad0928d7d3bdcacfa7b0c025b436fec3b57369e4b39R58-R60) [[2]](diffhunk://#diff-f6f8135a64d2f255a1c82ad0928d7d3bdcacfa7b0c025b436fec3b57369e4b39R170-R188)

**SDK and Manager Updates**
- Updated the Fairmatic SDK dependency from version 3.0.2 to 3.1.0 in `build.gradle`.
- Added `openIncidentReportingWebPage` method to `FairmaticManager` to wrap the SDK call.

**UI/Styling**
- Added a new color resource `colorButtonSecondary` for the new button's background.
- Added a string resource `open_incident_report` for the button text.